### PR TITLE
Check for running on Docker

### DIFF
--- a/src/UnixSocketInspection.php
+++ b/src/UnixSocketInspection.php
@@ -46,8 +46,13 @@ class UnixSocketInspection
 
     protected static function getRemotePidFromSocket($socket)
     {
-        // SO_PEERCRED = 17
-        $remotePid = socket_get_option($socket, SOL_SOCKET, 17);
+        // check if process runs in a docker container
+        if (is_file("/.dockerenv")) {
+            $remotePid = 1;
+        } else {
+            // SO_PEERCRED = 17
+            $remotePid = socket_get_option($socket, SOL_SOCKET, 17);
+        }
         if (! is_int($remotePid) || ! $remotePid > 0) {
             throw new RuntimeException("Remote PID expected, got " . var_export($remotePid));
         }


### PR DESCRIPTION
The assumption is that the process runs without any init-process in the Docker container - therefore PID=1

Context:
 We are running vSphereDB in a separate docker container. This change allows the IcingaWeb integration to run properly
![grafik](https://github.com/gipfl/socket/assets/5675208/3a619851-5756-4645-9282-78ab40008af2)
